### PR TITLE
Fix benchmark coverage and limit assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ obj
 *.db
 *.db-shm
 *.db-wal
+
+# BenchmarkDotNet files
+**/BenchmarkDotNet.Artifacts/*.log
+**/BenchmarkDotNet.Artifacts/results/*

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,5 +22,6 @@
     <PackageVersion Include="MSTest.TestFramework" Version="4.0.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>
 </Project>

--- a/FasTnT.Epcis.sln
+++ b/FasTnT.Epcis.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FasTnT.Host.Tests", "tests\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FasTnT.IntegrationTests", "tests\FasTnT.IntegrationTests\FasTnT.IntegrationTests.csproj", "{FF9D497A-BCDE-4950-9CC1-20F972570698}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FasTnT.PerformanceTests", "tests\FasTnT.PerformanceTests\FasTnT.PerformanceTests.csproj", "{8B7E5A3C-9D2F-4E6B-A1C8-3F9D8E7A5B4C}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{824F8BB3-D514-4EAA-BD29-434CC73DAB16}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Packages.props = Directory.Packages.props
@@ -72,6 +74,10 @@ Global
 		{FF9D497A-BCDE-4950-9CC1-20F972570698}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FF9D497A-BCDE-4950-9CC1-20F972570698}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FF9D497A-BCDE-4950-9CC1-20F972570698}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8B7E5A3C-9D2F-4E6B-A1C8-3F9D8E7A5B4C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8B7E5A3C-9D2F-4E6B-A1C8-3F9D8E7A5B4C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B7E5A3C-9D2F-4E6B-A1C8-3F9D8E7A5B4C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8B7E5A3C-9D2F-4E6B-A1C8-3F9D8E7A5B4C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -83,6 +89,7 @@ Global
 		{633B2FD9-D8E0-421B-B783-47CBC46A61D1} = {AEDA07AE-4296-487B-85F9-3BF23FD21AC9}
 		{247AE2F0-76CA-40BE-B7F1-696AD8FA9024} = {0D9E736D-BF92-400A-964E-FB0E708ED015}
 		{FF9D497A-BCDE-4950-9CC1-20F972570698} = {0D9E736D-BF92-400A-964E-FB0E708ED015}
+		{8B7E5A3C-9D2F-4E6B-A1C8-3F9D8E7A5B4C} = {0D9E736D-BF92-400A-964E-FB0E708ED015}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BD276E44-6D3E-4F0F-A9A1-89D1317C6286}

--- a/tests/FasTnT.PerformanceTests/Benchmarks/CaptureBenchmarks.cs
+++ b/tests/FasTnT.PerformanceTests/Benchmarks/CaptureBenchmarks.cs
@@ -1,0 +1,149 @@
+using BenchmarkDotNet.Attributes;
+using FasTnT.Application.Handlers;
+using FasTnT.Domain.Model;
+using FasTnT.Host.Communication.Json.Parsers;
+using FasTnT.Host.Communication.Xml.Parsers;
+using FasTnT.PerformanceTests.Config;
+using FasTnT.PerformanceTests.Helpers;
+using System.Text;
+
+namespace FasTnT.PerformanceTests.Benchmarks;
+
+[Config(typeof(BenchmarkConfig))]
+[MemoryDiagnoser]
+public class CaptureBenchmarks
+{
+    private EpcisContext _context = null!;
+    private CaptureHandler _captureHandler = null!;
+    private Dictionary<int, Request> _templateRequests = new();
+    private Dictionary<int, string> _xmlDocuments = new();
+    private Dictionary<int, string> _jsonDocuments = new();
+    private Dictionary<int, Request> _aggregationTemplateRequests = new();
+    private Dictionary<int, Request> _preParsedRequests = new();
+    private Dictionary<int, Request> _aggregationRequests = new();
+    private Namespaces _namespaces = null!;
+
+    [Params(100, 500)]
+    public int EventCount { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _context = BenchmarkDbContext.CreateInMemoryContext("CaptureBenchmarks");
+        _captureHandler = new CaptureHandler(
+            _context,
+            new TestCurrentUser(),
+            new NoOpEventNotifier(),
+            BenchmarkConstants.Create()
+        );
+
+        _namespaces = new Namespaces(new Dictionary<string, string>());
+
+        // Pre-generate template requests for all event counts
+        var eventCounts = new[] { 100, 500 };
+
+        foreach (var events in eventCounts)
+        {
+            // Generate mixed events (70% Object, 20% Aggregation, 10% Transformation)
+            var request = new Request
+            {
+                SchemaVersion = "2.0",
+                DocumentTime = DateTime.UtcNow,
+                Events = new List<Event>()
+            };
+
+            for (int i = 0; i < events; i++)
+            {
+                Event evt;
+                var ratio = (double)i / events;
+
+                if (ratio < 0.7)
+                {
+                    evt = TestDataGenerator.GenerateObjectEvent(50, i);
+                }
+                else if (ratio < 0.9)
+                {
+                    evt = TestDataGenerator.GenerateAggregationEvent(50, i);
+                }
+                else
+                {
+                    evt = TestDataGenerator.GenerateTransformationEvent(25, 25, i);
+                }
+
+                request.Events.Add(evt);
+            }
+
+            _templateRequests[events] = request;
+
+            // Generate XML and JSON documents
+            _xmlDocuments[events] = TestDataGenerator.GenerateXmlRequest(events, 50);
+            _jsonDocuments[events] = TestDataGenerator.GenerateJsonRequest(events, 50);
+
+            // Generate aggregation-heavy requests
+            var aggRequest = new Request
+            {
+                SchemaVersion = "2.0",
+                DocumentTime = DateTime.UtcNow,
+                Events = new List<Event>()
+            };
+
+            for (int i = 0; i < events; i++)
+            {
+                aggRequest.Events.Add(TestDataGenerator.GenerateAggregationEvent(50, i));
+            }
+
+            _aggregationTemplateRequests[events] = aggRequest;
+        }
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        BenchmarkDbContext.ClearDataAsync(_context).GetAwaiter().GetResult();
+        _context.ChangeTracker.Clear();
+
+        // Deep copy and reset requests to ensure EventId hashing and inserts execute every run
+        _preParsedRequests[EventCount] = TestDataGenerator.DeepCopyAndResetRequest(_templateRequests[EventCount]);
+        _aggregationRequests[EventCount] = TestDataGenerator.DeepCopyAndResetRequest(_aggregationTemplateRequests[EventCount]);
+    }
+
+    [Benchmark]
+    public async Task<Request> CaptureXmlEndToEnd()
+    {
+        var xml = _xmlDocuments[EventCount];
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var request = await XmlCaptureRequestParser.ParseAsync(stream, CancellationToken.None);
+
+        return await _captureHandler.StoreAsync(request, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<Request> CaptureJsonEndToEnd()
+    {
+        var json = _jsonDocuments[EventCount];
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        var request = await JsonCaptureRequestParser.ParseDocumentAsync(stream, _namespaces, CancellationToken.None);
+
+        return await _captureHandler.StoreAsync(request, CancellationToken.None);
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<Request> CapturePreParsedRequest()
+    {
+        var request = _preParsedRequests[EventCount];
+        return await _captureHandler.StoreAsync(request, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<Request> CaptureWithAggregations()
+    {
+        var request = _aggregationRequests[EventCount];
+        return await _captureHandler.StoreAsync(request, CancellationToken.None);
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        BenchmarkDbContext.Cleanup(_context);
+    }
+}

--- a/tests/FasTnT.PerformanceTests/Benchmarks/ComponentBenchmarks.cs
+++ b/tests/FasTnT.PerformanceTests/Benchmarks/ComponentBenchmarks.cs
@@ -1,0 +1,161 @@
+using BenchmarkDotNet.Attributes;
+using FasTnT.Application.Services.Events;
+using FasTnT.Application.Validators;
+using FasTnT.Domain.Enumerations;
+using FasTnT.Domain.Model;
+using FasTnT.Domain.Model.Events;
+using FasTnT.PerformanceTests.Config;
+using FasTnT.PerformanceTests.Helpers;
+
+namespace FasTnT.PerformanceTests.Benchmarks;
+
+[Config(typeof(BenchmarkConfig))]
+[MemoryDiagnoser]
+public class ComponentBenchmarks
+{
+    private EpcisContext _context = null!;
+    private Dictionary<int, Request> _validRequests = new();
+    private Dictionary<EventType, Event> _eventsByType = new();
+
+    [Params(100, 500)]
+    public int EventCount { get; set; }
+
+    [Params(EventType.ObjectEvent, EventType.AggregationEvent, EventType.TransformationEvent)]
+    public EventType EventTypeParam { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _context = BenchmarkDbContext.CreateInMemoryContext("ComponentBenchmarks");
+
+        // Pre-generate valid requests
+        var eventCounts = new[] { 100, 500 };
+
+        foreach (var events in eventCounts)
+        {
+            var request = new Request
+            {
+                SchemaVersion = "2.0",
+                DocumentTime = DateTime.UtcNow,
+                Events = new List<Event>()
+            };
+
+            for (int i = 0; i < events; i++)
+            {
+                request.Events.Add(TestDataGenerator.GenerateObjectEvent(50, i));
+            }
+
+            _validRequests[events] = request;
+        }
+
+        // Pre-generate events by type
+        _eventsByType[EventType.ObjectEvent] = TestDataGenerator.GenerateObjectEvent(50);
+        _eventsByType[EventType.AggregationEvent] = TestDataGenerator.GenerateAggregationEvent(50);
+        _eventsByType[EventType.TransformationEvent] = TestDataGenerator.GenerateTransformationEvent(25, 25);
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        BenchmarkDbContext.ClearDataAsync(_context).GetAwaiter().GetResult();
+        _context.ChangeTracker.Clear();
+    }
+
+    [Benchmark(Baseline = true)]
+    public bool ValidateRequest()
+    {
+        var request = _validRequests[EventCount];
+        return RequestValidator.IsValid(request);
+    }
+
+    [Benchmark]
+    public bool ValidateEvents()
+    {
+        var evt = _eventsByType[EventTypeParam];
+        return EventValidator.IsValid(evt);
+    }
+
+    [Benchmark]
+    public List<string> ComputeEventHashes()
+    {
+        var request = _validRequests[EventCount];
+        var hashes = new List<string>();
+
+        foreach (var evt in request.Events)
+        {
+            hashes.Add(EventHash.Compute(evt));
+        }
+
+        return hashes;
+    }
+
+    [Benchmark]
+    public async Task DatabaseInsertOnly()
+    {
+        var request = TestDataGenerator.DeepCopyAndResetRequest(_validRequests[EventCount]);
+
+        _context.Add(request);
+        await _context.SaveChangesAsync();
+
+        _context.Entry(request).State = Microsoft.EntityFrameworkCore.EntityState.Detached;
+        foreach (var evt in request.Events)
+        {
+            _context.Entry(evt).State = Microsoft.EntityFrameworkCore.EntityState.Detached;
+        }
+    }
+
+    [Benchmark]
+    public async Task DatabaseInsertWithTransaction()
+    {
+        var request = TestDataGenerator.DeepCopyAndResetRequest(_validRequests[EventCount]);
+
+        using var transaction = await _context.Database.BeginTransactionAsync();
+
+        _context.Add(request);
+        await _context.SaveChangesAsync();
+        request.RecordTime = DateTime.UtcNow;
+        await _context.SaveChangesAsync();
+
+        await transaction.CommitAsync();
+
+        _context.Entry(request).State = Microsoft.EntityFrameworkCore.EntityState.Detached;
+        foreach (var evt in request.Events)
+        {
+            _context.Entry(evt).State = Microsoft.EntityFrameworkCore.EntityState.Detached;
+        }
+    }
+
+    [Benchmark]
+    public async Task DatabaseBulkInsert()
+    {
+        const int requestCount = 10;
+        int eventsPerRequest = EventCount / requestCount;
+
+        for (int i = 0; i < requestCount; i++)
+        {
+            var request = new Request
+            {
+                SchemaVersion = "2.0",
+                DocumentTime = DateTime.UtcNow,
+                Events = new List<Event>()
+            };
+
+            for (int j = 0; j < eventsPerRequest; j++)
+            {
+                request.Events.Add(TestDataGenerator.GenerateObjectEvent(50, j));
+            }
+
+            _context.Add(request);
+        }
+
+        await _context.SaveChangesAsync();
+
+        _context.ChangeTracker.Clear();
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        BenchmarkDbContext.Cleanup(_context);
+    }
+}

--- a/tests/FasTnT.PerformanceTests/Benchmarks/EndToEndQueryBenchmarks.cs
+++ b/tests/FasTnT.PerformanceTests/Benchmarks/EndToEndQueryBenchmarks.cs
@@ -1,0 +1,167 @@
+using BenchmarkDotNet.Attributes;
+using FasTnT.Application.Database;
+using FasTnT.Host.Communication.Xml.Formatters;
+using FasTnT.Host.Communication.Json.Formatters;
+using FasTnT.Application.Handlers;
+using FasTnT.Domain.Model.Queries;
+using FasTnT.Host.Endpoints.Interfaces;
+using FasTnT.PerformanceTests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FasTnT.PerformanceTests.Benchmarks;
+
+[Config(typeof(BenchmarkConfig))]
+[MemoryDiagnoser]
+public class EndToEndQueryBenchmarks
+{
+    [Params(1000, 10000, 50000)]
+    public int DatabaseSize { get; set; }
+
+    [Params("Xml", "Json")]
+    public string Format { get; set; } = null!;
+
+    private EpcisContext _context1K = null!;
+    private EpcisContext _context10K = null!;
+    private EpcisContext _context50K = null!;
+    private DataRetrieverHandler _handler1K = null!;
+    private DataRetrieverHandler _handler10K = null!;
+    private DataRetrieverHandler _handler50K = null!;
+
+    private string _testEpc = null!;
+    private string _testBizStep = null!;
+    private string _testDisposition = null!;
+    private DateTime _startDate;
+    private DateTime _endDate;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        // Create and populate databases
+        _context1K = BenchmarkDbContext.CreateInMemoryContext("EndToEndBenchmarks_1K");
+        TestDataGenerator.PopulateDatabaseWithEvents(_context1K, 1000);
+
+        _context10K = BenchmarkDbContext.CreateInMemoryContext("EndToEndBenchmarks_10K");
+        TestDataGenerator.PopulateDatabaseWithEvents(_context10K, 10000);
+
+        _context50K = BenchmarkDbContext.CreateInMemoryContext("EndToEndBenchmarks_50K");
+        TestDataGenerator.PopulateDatabaseWithEvents(_context50K, 50000);
+
+        // Initialize handlers
+        var constants = BenchmarkConstants.CreateForQueries(maxEventsReturned: 60000);
+        _handler1K = new DataRetrieverHandler(_context1K, new TestCurrentUser(), constants);
+        _handler10K = new DataRetrieverHandler(_context10K, new TestCurrentUser(), constants);
+        _handler50K = new DataRetrieverHandler(_context50K, new TestCurrentUser(), constants);
+
+        // Pre-generate test values
+        _testEpc = TestDataGenerator.GenerateRandomEpc(0, 0);
+        _testBizStep = "urn:epcglobal:cbv:bizstep:shipping";
+        _testDisposition = "urn:epcglobal:cbv:disp:in_transit";
+        _startDate = DateTime.UtcNow.AddDays(-30);
+        _endDate = DateTime.UtcNow;
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        _context1K.ChangeTracker.Clear();
+        _context10K.ChangeTracker.Clear();
+        _context50K.ChangeTracker.Clear();
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        BenchmarkDbContext.Cleanup(_context1K);
+        BenchmarkDbContext.Cleanup(_context10K);
+        BenchmarkDbContext.Cleanup(_context50K);
+    }
+
+    private EpcisContext GetCurrentContext()
+    {
+        return DatabaseSize switch
+        {
+            1000 => _context1K,
+            10000 => _context10K,
+            50000 => _context50K,
+            _ => throw new InvalidOperationException($"Invalid DatabaseSize: {DatabaseSize}")
+        };
+    }
+
+    private DataRetrieverHandler GetCurrentHandler()
+    {
+        return DatabaseSize switch
+        {
+            1000 => _handler1K,
+            10000 => _handler10K,
+            50000 => _handler50K,
+            _ => throw new InvalidOperationException($"Invalid DatabaseSize: {DatabaseSize}")
+        };
+    }
+
+    private string FormatResponse(QueryResponse response)
+    {
+        var result = new QueryResult(response);
+        return Format switch
+        {
+            "Xml" => XmlResponseFormatter.Format(result),
+            "Json" => JsonResponseFormatter.Format(result),
+            _ => throw new InvalidOperationException($"Invalid Format: {Format}")
+        };
+    }
+
+    [Benchmark]
+    public async Task<string> EndToEndSimpleQuery()
+    {
+        var parameters = new[] { QueryParameter.Create("MATCH_anyEPC", _testEpc) };
+        var handler = GetCurrentHandler();
+        var events = await handler.QueryEventsAsync(parameters, CancellationToken.None);
+        var response = TestDataGenerator.CreateQueryResponse(events);
+        return FormatResponse(response);
+    }
+
+    [Benchmark]
+    public async Task<string> EndToEndComplexQuery()
+    {
+        var parameters = new[]
+        {
+            QueryParameter.Create("MATCH_anyEPC", _testEpc),
+            QueryParameter.Create("GE_eventTime", _startDate.ToString("o")),
+            QueryParameter.Create("LT_eventTime", _endDate.ToString("o")),
+            QueryParameter.Create("EQ_bizStep", _testBizStep),
+            QueryParameter.Create("EQ_disposition", _testDisposition)
+        };
+        var handler = GetCurrentHandler();
+        var events = await handler.QueryEventsAsync(parameters, CancellationToken.None);
+        var response = TestDataGenerator.CreateQueryResponse(events);
+        return FormatResponse(response);
+    }
+
+    [Benchmark]
+    public async Task<string> EndToEndLargeResultSet()
+    {
+        var parameters = new[]
+        {
+            QueryParameter.Create("eventType", "ObjectEvent"),
+            QueryParameter.Create("maxEventCount", "60000"),
+            QueryParameter.Create("perPage", "60000")
+        };
+        var handler = GetCurrentHandler();
+        var events = await handler.QueryEventsAsync(parameters, CancellationToken.None);
+        var response = TestDataGenerator.CreateQueryResponse(events);
+        return FormatResponse(response);
+    }
+
+    [Benchmark]
+    public async Task<string> EndToEndWithPagination()
+    {
+        var parameters = new[]
+        {
+            QueryParameter.Create("eventType", "ObjectEvent"),
+            QueryParameter.Create("perPage", "100")
+        };
+        var handler = GetCurrentHandler();
+        var events = await handler.QueryEventsAsync(parameters, CancellationToken.None);
+        var response = TestDataGenerator.CreateQueryResponse(events);
+        return FormatResponse(response);
+    }
+}

--- a/tests/FasTnT.PerformanceTests/Benchmarks/JsonParsingBenchmarks.cs
+++ b/tests/FasTnT.PerformanceTests/Benchmarks/JsonParsingBenchmarks.cs
@@ -1,0 +1,86 @@
+using BenchmarkDotNet.Attributes;
+using FasTnT.Domain.Model;
+using FasTnT.Host.Communication.Json.Parsers;
+using FasTnT.PerformanceTests.Config;
+using FasTnT.PerformanceTests.Helpers;
+using System.Text;
+using System.Text.Json;
+
+namespace FasTnT.PerformanceTests.Benchmarks;
+
+[Config(typeof(BenchmarkConfig))]
+[MemoryDiagnoser]
+public class JsonParsingBenchmarks
+{
+    private Dictionary<(int events, int epcs), string> _jsonData = new();
+    private Dictionary<(int events, int epcs), string> _jsonMixedData = new();
+    private Namespaces _namespaces = null!;
+
+    [Params(100, 500, 1000, 5000, 10000)]
+    public int EventCount { get; set; }
+
+    [Params(10, 50, 100)]
+    public int EpcsPerEvent { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _namespaces = new Namespaces(new Dictionary<string, string>());
+
+        // Generate JSON strings for all parameter combinations
+        var eventCounts = new[] { 100, 500, 1000, 5000, 10000 };
+        var epcCounts = new[] { 10, 50, 100 };
+
+        foreach (var events in eventCounts)
+        {
+            foreach (var epcs in epcCounts)
+            {
+                var json = TestDataGenerator.GenerateJsonRequest(events, epcs);
+                _jsonData[(events, epcs)] = json;
+
+                var jsonMixed = TestDataGenerator.GenerateJsonMixedRequest(events, epcs);
+                _jsonMixedData[(events, epcs)] = jsonMixed;
+            }
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<Request> ParseJsonDocument()
+    {
+        var json = _jsonData[(EventCount, EpcsPerEvent)];
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+        return await JsonCaptureRequestParser.ParseDocumentAsync(stream, _namespaces, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<Request> ParseJsonMixedDocument()
+    {
+        var json = _jsonMixedData[(EventCount, EpcsPerEvent)];
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+        return await JsonCaptureRequestParser.ParseDocumentAsync(stream, _namespaces, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<Request> ParseJsonEvent()
+    {
+        var json = _jsonData[(EventCount, EpcsPerEvent)];
+        using var document = JsonDocument.Parse(json);
+        var eventList = document.RootElement.GetProperty("epcisBody").GetProperty("eventList");
+        var firstEvent = eventList.EnumerateArray().First();
+
+        // Serialize the first event back to JSON and create a stream
+        var eventJson = JsonSerializer.Serialize(firstEvent);
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(eventJson));
+
+        return await JsonCaptureRequestParser.ParseEventAsync(stream, _namespaces, CancellationToken.None);
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        _jsonData.Clear();
+        _jsonMixedData.Clear();
+    }
+}

--- a/tests/FasTnT.PerformanceTests/Benchmarks/LimitTestBenchmarks.cs
+++ b/tests/FasTnT.PerformanceTests/Benchmarks/LimitTestBenchmarks.cs
@@ -1,0 +1,105 @@
+using BenchmarkDotNet.Attributes;
+using FasTnT.Application.Handlers;
+using FasTnT.Domain.Exceptions;
+using FasTnT.Domain.Model;
+using FasTnT.PerformanceTests.Config;
+using FasTnT.PerformanceTests.Helpers;
+
+namespace FasTnT.PerformanceTests.Benchmarks;
+
+[Config(typeof(BenchmarkConfig))]
+[MemoryDiagnoser]
+public class LimitTestBenchmarks
+{
+    private EpcisContext _context = null!;
+    private CaptureHandler _limitedCaptureHandler = null!;
+    private Dictionary<int, Request> _templateRequests = new();
+    private Dictionary<int, Request> _requests = new();
+
+    [Params(500, 501, 1000, 5000)]
+    public int EventCountForLimitTest { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _context = BenchmarkDbContext.CreateInMemoryContext("LimitTestBenchmarks");
+
+        // Handler with production limit
+        _limitedCaptureHandler = new CaptureHandler(
+            _context,
+            new TestCurrentUser(),
+            new NoOpEventNotifier(),
+            BenchmarkConstants.Create(maxEventsPerCall: 500)
+        );
+
+        // Pre-generate template requests for limit testing
+        var eventCounts = new[] { 500, 501, 1000, 5000 };
+
+        foreach (var events in eventCounts)
+        {
+            var request = new Request
+            {
+                SchemaVersion = "2.0",
+                DocumentTime = DateTime.UtcNow,
+                Events = new List<Event>()
+            };
+
+            for (int i = 0; i < events; i++)
+            {
+                request.Events.Add(TestDataGenerator.GenerateObjectEvent(75, i));
+            }
+
+            _templateRequests[events] = request;
+        }
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        BenchmarkDbContext.ClearDataAsync(_context).GetAwaiter().GetResult();
+        _context.ChangeTracker.Clear();
+
+        // Deep copy and reset requests to ensure EventId hashing and inserts execute every run
+        _requests[500] = TestDataGenerator.DeepCopyAndResetRequest(_templateRequests[500]);
+        _requests[EventCountForLimitTest] = TestDataGenerator.DeepCopyAndResetRequest(_templateRequests[EventCountForLimitTest]);
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<Request> CaptureAtMaxLimit()
+    {
+        var request = _requests[500];
+        return await _limitedCaptureHandler.StoreAsync(request, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task CaptureExceedingLimit()
+    {
+        var request = _requests[EventCountForLimitTest];
+        var exceptionThrown = false;
+
+        try
+        {
+            await _limitedCaptureHandler.StoreAsync(request, CancellationToken.None);
+        }
+        catch (EpcisException ex) when (ex.ExceptionType == ExceptionType.CaptureLimitExceededException)
+        {
+            exceptionThrown = true;
+        }
+
+        // Assert that exception was thrown for counts > 500
+        if (EventCountForLimitTest > 500 && !exceptionThrown)
+        {
+            throw new InvalidOperationException($"Expected CaptureLimitExceededException for {EventCountForLimitTest} events (limit: 500), but no exception was thrown.");
+        }
+        else if (EventCountForLimitTest <= 500 && exceptionThrown)
+        {
+            throw new InvalidOperationException($"Did not expect CaptureLimitExceededException for {EventCountForLimitTest} events (limit: 500), but one was thrown.");
+        }
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        BenchmarkDbContext.Cleanup(_context);
+    }
+}

--- a/tests/FasTnT.PerformanceTests/Benchmarks/QueryBenchmarks.cs
+++ b/tests/FasTnT.PerformanceTests/Benchmarks/QueryBenchmarks.cs
@@ -1,0 +1,195 @@
+using BenchmarkDotNet.Attributes;
+using FasTnT.Application.Database;
+using FasTnT.Application.Handlers;
+using FasTnT.Domain.Model;
+using FasTnT.Domain.Model.Queries;
+using FasTnT.PerformanceTests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FasTnT.PerformanceTests.Benchmarks;
+
+[Config(typeof(BenchmarkConfig))]
+[MemoryDiagnoser]
+public class QueryBenchmarks
+{
+    [Params(1000, 10000, 50000)]
+    public int DatabaseSize { get; set; }
+
+    private EpcisContext _context1K = null!;
+    private EpcisContext _context10K = null!;
+    private EpcisContext _context50K = null!;
+    private DataRetrieverHandler _handler1K = null!;
+    private DataRetrieverHandler _handler10K = null!;
+    private DataRetrieverHandler _handler50K = null!;
+
+    private string _testEpc = null!;
+    private string _testBizStep = null!;
+    private string _testDisposition = null!;
+    private string _testReadPoint = null!;
+    private string _testBizLocation = null!;
+    private DateTime _startDate;
+    private DateTime _endDate;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        // Create and populate 1K database
+        _context1K = BenchmarkDbContext.CreateInMemoryContext("QueryBenchmarks_1K");
+        TestDataGenerator.PopulateDatabaseWithEvents(_context1K, 1000);
+
+        // Create and populate 10K database
+        _context10K = BenchmarkDbContext.CreateInMemoryContext("QueryBenchmarks_10K");
+        TestDataGenerator.PopulateDatabaseWithEvents(_context10K, 10000);
+
+        // Create and populate 50K database
+        _context50K = BenchmarkDbContext.CreateInMemoryContext("QueryBenchmarks_50K");
+        TestDataGenerator.PopulateDatabaseWithEvents(_context50K, 50000);
+
+        // Initialize handlers per context
+        var constants = BenchmarkConstants.CreateForQueries(maxEventsReturned: 60000);
+        _handler1K = new DataRetrieverHandler(_context1K, new TestCurrentUser(), constants);
+        _handler10K = new DataRetrieverHandler(_context10K, new TestCurrentUser(), constants);
+        _handler50K = new DataRetrieverHandler(_context50K, new TestCurrentUser(), constants);
+
+        // Pre-generate test values (using values from the generated data)
+        _testEpc = TestDataGenerator.GenerateRandomEpc(0, 0);
+        _testBizStep = "urn:epcglobal:cbv:bizstep:shipping";
+        _testDisposition = "urn:epcglobal:cbv:disp:in_transit";
+        _testReadPoint = "urn:epc:id:sgln:0614141.07346.0";
+        _testBizLocation = "urn:epc:id:sgln:0614141.07346.0";
+        _startDate = DateTime.UtcNow.AddDays(-30);
+        _endDate = DateTime.UtcNow;
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        // Clear change tracker for clean state
+        _context1K.ChangeTracker.Clear();
+        _context10K.ChangeTracker.Clear();
+        _context50K.ChangeTracker.Clear();
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        BenchmarkDbContext.Cleanup(_context1K);
+        BenchmarkDbContext.Cleanup(_context10K);
+        BenchmarkDbContext.Cleanup(_context50K);
+    }
+
+    private EpcisContext GetCurrentContext()
+    {
+        return DatabaseSize switch
+        {
+            1000 => _context1K,
+            10000 => _context10K,
+            50000 => _context50K,
+            _ => throw new InvalidOperationException($"Invalid DatabaseSize: {DatabaseSize}")
+        };
+    }
+
+    private DataRetrieverHandler GetCurrentHandler()
+    {
+        return DatabaseSize switch
+        {
+            1000 => _handler1K,
+            10000 => _handler10K,
+            50000 => _handler50K,
+            _ => throw new InvalidOperationException($"Invalid DatabaseSize: {DatabaseSize}")
+        };
+    }
+
+    [Benchmark]
+    public async Task<List<Event>> QueryByEpc()
+    {
+        var parameters = new[] { QueryParameter.Create("MATCH_anyEPC", _testEpc) };
+        var handler = GetCurrentHandler();
+        return await handler.QueryEventsAsync(parameters, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<List<Event>> QueryByEventType()
+    {
+        var parameters = new[]
+        {
+            QueryParameter.Create("eventType", "ObjectEvent"),
+            QueryParameter.Create("maxEventCount", "60000")
+        };
+        var handler = GetCurrentHandler();
+        return await handler.QueryEventsAsync(parameters, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<List<Event>> QueryByBizStep()
+    {
+        var parameters = new[] { QueryParameter.Create("EQ_bizStep", _testBizStep) };
+        var handler = GetCurrentHandler();
+        return await handler.QueryEventsAsync(parameters, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<List<Event>> QueryByDisposition()
+    {
+        var parameters = new[] { QueryParameter.Create("EQ_disposition", _testDisposition) };
+        var handler = GetCurrentHandler();
+        return await handler.QueryEventsAsync(parameters, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<List<Event>> QueryByReadPoint()
+    {
+        var parameters = new[] { QueryParameter.Create("EQ_readPoint", _testReadPoint) };
+        var handler = GetCurrentHandler();
+        return await handler.QueryEventsAsync(parameters, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<List<Event>> QueryByBizLocation()
+    {
+        var parameters = new[] { QueryParameter.Create("EQ_bizLocation", _testBizLocation) };
+        var handler = GetCurrentHandler();
+        return await handler.QueryEventsAsync(parameters, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<List<Event>> QueryByDateRange()
+    {
+        var parameters = new[]
+        {
+            QueryParameter.Create("GE_eventTime", _startDate.ToString("o")),
+            QueryParameter.Create("LT_eventTime", _endDate.ToString("o")),
+            QueryParameter.Create("maxEventCount", "60000"),
+            QueryParameter.Create("perPage", "60000")
+        };
+        var handler = GetCurrentHandler();
+        return await handler.QueryEventsAsync(parameters, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<List<Event>> QueryComplex()
+    {
+        var parameters = new[]
+        {
+            QueryParameter.Create("MATCH_anyEPC", _testEpc),
+            QueryParameter.Create("GE_eventTime", _startDate.ToString("o")),
+            QueryParameter.Create("LT_eventTime", _endDate.ToString("o")),
+            QueryParameter.Create("EQ_bizStep", _testBizStep),
+            QueryParameter.Create("EQ_disposition", _testDisposition)
+        };
+        var handler = GetCurrentHandler();
+        return await handler.QueryEventsAsync(parameters, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<List<Event>> QueryWithPagination()
+    {
+        var parameters = new[]
+        {
+            QueryParameter.Create("eventType", "ObjectEvent"),
+            QueryParameter.Create("perPage", "100")
+        };
+        var handler = GetCurrentHandler();
+        return await handler.QueryEventsAsync(parameters, CancellationToken.None);
+    }
+}

--- a/tests/FasTnT.PerformanceTests/Benchmarks/SerializationBenchmarks.cs
+++ b/tests/FasTnT.PerformanceTests/Benchmarks/SerializationBenchmarks.cs
@@ -1,0 +1,95 @@
+using BenchmarkDotNet.Attributes;
+using FasTnT.Host.Communication.Xml.Formatters;
+using FasTnT.Host.Communication.Json.Formatters;
+using FasTnT.Domain.Model;
+using FasTnT.Domain.Model.Queries;
+using FasTnT.Host.Endpoints.Interfaces;
+using FasTnT.PerformanceTests.Helpers;
+
+namespace FasTnT.PerformanceTests.Benchmarks;
+
+[Config(typeof(BenchmarkConfig))]
+[MemoryDiagnoser]
+public class SerializationBenchmarks
+{
+    [Params(100, 500)]
+    public int ResultSize { get; set; }
+
+    private Dictionary<int, QueryResponse> _standardResponses = null!;
+    private Dictionary<int, QueryResponse> _customFieldResponses = null!;
+    private Dictionary<int, QueryResponse> _sensorDataResponses = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+
+        // Pre-generate standard event responses
+        _standardResponses = new Dictionary<int, QueryResponse>
+        {
+            { 100, TestDataGenerator.CreateQueryResponse(TestDataGenerator.GenerateMixedEvents(100)) },
+            { 500, TestDataGenerator.CreateQueryResponse(TestDataGenerator.GenerateMixedEvents(500)) }
+        };
+
+        // Pre-generate events with custom fields
+        _customFieldResponses = new Dictionary<int, QueryResponse>
+        {
+            { 100, TestDataGenerator.CreateQueryResponse(TestDataGenerator.GenerateEventsWithCustomFields(100)) },
+            { 500, TestDataGenerator.CreateQueryResponse(TestDataGenerator.GenerateEventsWithCustomFields(500)) }
+        };
+
+        // Pre-generate events with sensor data
+        _sensorDataResponses = new Dictionary<int, QueryResponse>
+        {
+            { 100, TestDataGenerator.CreateQueryResponse(TestDataGenerator.GenerateEventsWithSensorData(100)) },
+            { 500, TestDataGenerator.CreateQueryResponse(TestDataGenerator.GenerateEventsWithSensorData(500)) }
+        };
+    }
+
+    [Benchmark]
+    public string SerializeToXml()
+    {
+        var response = _standardResponses[ResultSize];
+        var result = new QueryResult(response);
+        return XmlResponseFormatter.Format(result);
+    }
+
+    [Benchmark]
+    public string SerializeToJson()
+    {
+        var response = _standardResponses[ResultSize];
+        var result = new QueryResult(response);
+        return JsonResponseFormatter.Format(result);
+    }
+
+    [Benchmark]
+    public string SerializeXmlWithCustomFields()
+    {
+        var response = _customFieldResponses[ResultSize];
+        var result = new QueryResult(response);
+        return XmlResponseFormatter.Format(result);
+    }
+
+    [Benchmark]
+    public string SerializeJsonWithCustomFields()
+    {
+        var response = _customFieldResponses[ResultSize];
+        var result = new QueryResult(response);
+        return JsonResponseFormatter.Format(result);
+    }
+
+    [Benchmark]
+    public string SerializeXmlWithSensorData()
+    {
+        var response = _sensorDataResponses[ResultSize];
+        var result = new QueryResult(response);
+        return XmlResponseFormatter.Format(result);
+    }
+
+    [Benchmark]
+    public string SerializeJsonWithSensorData()
+    {
+        var response = _sensorDataResponses[ResultSize];
+        var result = new QueryResult(response);
+        return JsonResponseFormatter.Format(result);
+    }
+}

--- a/tests/FasTnT.PerformanceTests/Benchmarks/StressTestBenchmarks.cs
+++ b/tests/FasTnT.PerformanceTests/Benchmarks/StressTestBenchmarks.cs
@@ -1,0 +1,223 @@
+using BenchmarkDotNet.Attributes;
+using FasTnT.Application.Handlers;
+using FasTnT.Domain.Exceptions;
+using FasTnT.Domain.Model;
+using FasTnT.Host.Communication.Json.Parsers;
+using FasTnT.Host.Communication.Xml.Parsers;
+using FasTnT.PerformanceTests.Config;
+using FasTnT.PerformanceTests.Helpers;
+using System.Text;
+
+namespace FasTnT.PerformanceTests.Benchmarks;
+
+[Config(typeof(BenchmarkConfig))]
+[MemoryDiagnoser]
+public class StressTestBenchmarks
+{
+    private EpcisContext _context = null!;
+    private CaptureHandler _captureHandler = null!;
+    private CaptureHandler _limitedCaptureHandler = null!;
+    private Dictionary<int, string> _largeXmlDocuments = new();
+    private Dictionary<int, string> _largeJsonDocuments = new();
+    private Request _mixedWorkloadTemplateRequest = null!;
+    private Request _mixedWorkloadRequest = null!;
+    private Dictionary<int, Request> _limitTestTemplateRequests = new();
+    private Dictionary<int, Request> _limitTestRequests = new();
+    private Random _random = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _context = BenchmarkDbContext.CreateInMemoryContext("StressTestBenchmarks");
+        _random = new Random(42);
+
+        // Handler with high limit for stress testing
+        _captureHandler = new CaptureHandler(
+            _context,
+            new TestCurrentUser(),
+            new NoOpEventNotifier(),
+            BenchmarkConstants.Create(maxEventsPerCall: 10000)
+        );
+
+        // Handler with production limit for limit testing
+        _limitedCaptureHandler = new CaptureHandler(
+            _context,
+            new TestCurrentUser(),
+            new NoOpEventNotifier(),
+            BenchmarkConstants.Create(maxEventsPerCall: 500)
+        );
+
+        // Generate large XML documents
+        _largeXmlDocuments[5000] = TestDataGenerator.GenerateXmlRequest(5000, 100);
+        _largeXmlDocuments[10000] = TestDataGenerator.GenerateXmlRequest(10000, 100);
+
+        // Generate large JSON documents
+        _largeJsonDocuments[5000] = TestDataGenerator.GenerateJsonRequest(5000, 100);
+        _largeJsonDocuments[10000] = TestDataGenerator.GenerateJsonRequest(10000, 100);
+
+        // Generate realistic mixed workload template (70% Object, 20% Aggregation, 10% Transformation)
+        _mixedWorkloadTemplateRequest = new Request
+        {
+            SchemaVersion = "2.0",
+            DocumentTime = DateTime.UtcNow,
+            Events = new List<Event>()
+        };
+
+        for (int i = 0; i < 1000; i++)
+        {
+            Event evt;
+            var ratio = (double)i / 1000;
+            var epcCount = _random.Next(10, 101); // 10-100 EPCs per event
+
+            if (ratio < 0.7)
+            {
+                evt = TestDataGenerator.GenerateObjectEvent(epcCount, i);
+            }
+            else if (ratio < 0.9)
+            {
+                evt = TestDataGenerator.GenerateAggregationEvent(epcCount, i);
+            }
+            else
+            {
+                evt = TestDataGenerator.GenerateTransformationEvent(epcCount / 2, epcCount / 2, i);
+            }
+
+            _mixedWorkloadTemplateRequest.Events.Add(evt);
+        }
+
+        // Pre-generate template requests for limit testing
+        var limitTestEventCounts = new[] { 500, 501, 1000 };
+
+        foreach (var events in limitTestEventCounts)
+        {
+            var request = new Request
+            {
+                SchemaVersion = "2.0",
+                DocumentTime = DateTime.UtcNow,
+                Events = new List<Event>()
+            };
+
+            for (int i = 0; i < events; i++)
+            {
+                request.Events.Add(TestDataGenerator.GenerateObjectEvent(75, i));
+            }
+
+            _limitTestTemplateRequests[events] = request;
+        }
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        BenchmarkDbContext.ClearDataAsync(_context).GetAwaiter().GetResult();
+        _context.ChangeTracker.Clear();
+
+        // Deep copy and reset requests to ensure EventId hashing and inserts execute every run
+        _mixedWorkloadRequest = TestDataGenerator.DeepCopyAndResetRequest(_mixedWorkloadTemplateRequest);
+
+        // Deep copy and reset limit test requests
+        foreach (var eventCount in new[] { 500, 501, 1000 })
+        {
+            _limitTestRequests[eventCount] = TestDataGenerator.DeepCopyAndResetRequest(_limitTestTemplateRequests[eventCount]);
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<Request> CaptureLargeXmlDocument()
+    {
+        var xml = _largeXmlDocuments[5000];
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var request = await XmlCaptureRequestParser.ParseAsync(stream, CancellationToken.None);
+        return await _captureHandler.StoreAsync(request, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<Request> CaptureLargeJsonDocument()
+    {
+        var json = _largeJsonDocuments[5000];
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        var namespaces = new Namespaces(new Dictionary<string, string>());
+        var request = await JsonCaptureRequestParser.ParseDocumentAsync(stream, namespaces, CancellationToken.None);
+        return await _captureHandler.StoreAsync(request, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<Request> CaptureVeryLargeXmlDocument()
+    {
+        var xml = _largeXmlDocuments[10000];
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var request = await XmlCaptureRequestParser.ParseAsync(stream, CancellationToken.None);
+        return await _captureHandler.StoreAsync(request, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<Request> CaptureVeryLargeJsonDocument()
+    {
+        var json = _largeJsonDocuments[10000];
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        var namespaces = new Namespaces(new Dictionary<string, string>());
+        var request = await JsonCaptureRequestParser.ParseDocumentAsync(stream, namespaces, CancellationToken.None);
+        return await _captureHandler.StoreAsync(request, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<Request> CaptureRealisticMixedWorkload()
+    {
+        return await _captureHandler.StoreAsync(_mixedWorkloadRequest, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<Request> CaptureAtConfiguredLimit()
+    {
+        var request = _limitTestRequests[500];
+        return await _limitedCaptureHandler.StoreAsync(request, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task CaptureExceedingLimitBy1()
+    {
+        var request = _limitTestRequests[501];
+        var exceptionThrown = false;
+
+        try
+        {
+            await _limitedCaptureHandler.StoreAsync(request, CancellationToken.None);
+        }
+        catch (EpcisException ex) when (ex.ExceptionType == ExceptionType.CaptureLimitExceededException)
+        {
+            exceptionThrown = true;
+        }
+
+        if (!exceptionThrown)
+        {
+            throw new InvalidOperationException($"Expected CaptureLimitExceededException for 501 events (limit: 500), but no exception was thrown.");
+        }
+    }
+
+    [Benchmark]
+    public async Task CaptureExceedingLimitBy500()
+    {
+        var request = _limitTestRequests[1000];
+        var exceptionThrown = false;
+
+        try
+        {
+            await _limitedCaptureHandler.StoreAsync(request, CancellationToken.None);
+        }
+        catch (EpcisException ex) when (ex.ExceptionType == ExceptionType.CaptureLimitExceededException)
+        {
+            exceptionThrown = true;
+        }
+
+        if (!exceptionThrown)
+        {
+            throw new InvalidOperationException($"Expected CaptureLimitExceededException for 1000 events (limit: 500), but no exception was thrown.");
+        }
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        BenchmarkDbContext.Cleanup(_context);
+    }
+}

--- a/tests/FasTnT.PerformanceTests/Benchmarks/XmlParsingBenchmarks.cs
+++ b/tests/FasTnT.PerformanceTests/Benchmarks/XmlParsingBenchmarks.cs
@@ -1,0 +1,67 @@
+using BenchmarkDotNet.Attributes;
+using FasTnT.Domain.Model;
+using FasTnT.Host.Communication.Xml.Parsers;
+using FasTnT.PerformanceTests.Config;
+using FasTnT.PerformanceTests.Helpers;
+using System.Text;
+
+namespace FasTnT.PerformanceTests.Benchmarks;
+
+[Config(typeof(BenchmarkConfig))]
+[MemoryDiagnoser]
+public class XmlParsingBenchmarks
+{
+    private Dictionary<(int events, int epcs), string> _xmlData = new();
+    private Dictionary<(int events, int epcs), string> _xmlMixedData = new();
+
+    [Params(100, 500)]
+    public int EventCount { get; set; }
+
+    [Params(10, 50, 100)]
+    public int EpcsPerEvent { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        // Generate XML strings for all parameter combinations
+        var eventCounts = new[] { 100, 500 };
+        var epcCounts = new[] { 10, 50, 100 };
+
+        foreach (var events in eventCounts)
+        {
+            foreach (var epcs in epcCounts)
+            {
+                var xml = TestDataGenerator.GenerateXmlRequest(events, epcs);
+                _xmlData[(events, epcs)] = xml;
+
+                var xmlMixed = TestDataGenerator.GenerateXmlMixedRequest(events, epcs);
+                _xmlMixedData[(events, epcs)] = xmlMixed;
+            }
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<Request> ParseXmlDocument()
+    {
+        var xml = _xmlData[(EventCount, EpcsPerEvent)];
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+        return await XmlCaptureRequestParser.ParseAsync(stream, CancellationToken.None);
+    }
+
+    [Benchmark]
+    public async Task<Request> ParseXmlMixedDocument()
+    {
+        var xml = _xmlMixedData[(EventCount, EpcsPerEvent)];
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+        return await XmlCaptureRequestParser.ParseAsync(stream, CancellationToken.None);
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        _xmlData.Clear();
+        _xmlMixedData.Clear();
+    }
+}

--- a/tests/FasTnT.PerformanceTests/Config/BenchmarkConfig.cs
+++ b/tests/FasTnT.PerformanceTests/Config/BenchmarkConfig.cs
@@ -1,0 +1,45 @@
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Exporters.Csv;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Validators;
+
+namespace FasTnT.PerformanceTests.Config;
+
+public class BenchmarkConfig : ManualConfig
+{
+    public BenchmarkConfig()
+    {
+        // Add memory diagnostics to track allocations
+        AddDiagnoser(MemoryDiagnoser.Default);
+
+        // Add standard columns
+        AddColumn(StatisticColumn.Mean);
+        AddColumn(StatisticColumn.StdDev);
+        AddColumn(StatisticColumn.Median);
+        AddColumn(StatisticColumn.OperationsPerSecond);
+
+        // Configure exporters for report generation
+        AddExporter(HtmlExporter.Default);
+        AddExporter(MarkdownExporter.GitHub);
+        AddExporter(CsvExporter.Default);
+
+        // Configure job settings for reliable benchmarking
+        AddJob(Job.Default
+            .WithId("PerformanceTests")
+            .WithPlatform(BenchmarkDotNet.Environments.Platform.X64)
+            .WithJit(BenchmarkDotNet.Environments.Jit.RyuJit)
+            .WithMinIterationCount(5)
+            .WithMaxIterationCount(20)
+        );
+
+        // Add baseline validation
+        AddValidator(JitOptimizationsValidator.FailOnError);
+
+        // Configure summary style
+        WithSummaryStyle(BenchmarkDotNet.Reports.SummaryStyle.Default.WithRatioStyle(RatioStyle.Trend));
+    }
+}

--- a/tests/FasTnT.PerformanceTests/FasTnT.PerformanceTests.csproj
+++ b/tests/FasTnT.PerformanceTests/FasTnT.PerformanceTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FasTnT.Application\FasTnT.Application.csproj" />
+    <ProjectReference Include="..\..\src\FasTnT.Domain\FasTnT.Domain.csproj" />
+    <ProjectReference Include="..\..\src\FasTnT.Host\FasTnT.Host.csproj" />
+    <ProjectReference Include="..\..\src\Providers\FasTnT.Sqlite\FasTnT.Sqlite.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/FasTnT.PerformanceTests/GlobalUsings.cs
+++ b/tests/FasTnT.PerformanceTests/GlobalUsings.cs
@@ -1,0 +1,15 @@
+global using BenchmarkDotNet.Attributes;
+global using BenchmarkDotNet.Running;
+global using FasTnT.Application.Database;
+global using FasTnT.Application.Handlers;
+global using FasTnT.Application.Services.Notifications;
+global using FasTnT.Application.Services.Users;
+global using FasTnT.Domain.Model;
+global using FasTnT.Domain.Model.Events;
+global using FasTnT.Host.Communication.Json.Parsers;
+global using FasTnT.Host.Communication.Xml.Parsers;
+global using FasTnT.PerformanceTests.Config;
+global using FasTnT.PerformanceTests.Helpers;
+global using Microsoft.EntityFrameworkCore;
+global using Microsoft.Extensions.Options;
+global using System.Text;

--- a/tests/FasTnT.PerformanceTests/Helpers/BenchmarkConstants.cs
+++ b/tests/FasTnT.PerformanceTests/Helpers/BenchmarkConstants.cs
@@ -1,0 +1,46 @@
+using FasTnT.Application.Services.Notifications;
+using FasTnT.Application.Services.Users;
+using FasTnT.Domain;
+using FasTnT.Domain.Model;
+using FasTnT.Domain.Model.Queries;
+using FasTnT.Domain.Model.Subscriptions;
+using Microsoft.Extensions.Options;
+
+namespace FasTnT.PerformanceTests.Helpers;
+
+public class TestCurrentUser : ICurrentUser
+{
+    public string UserId => "benchmark_user";
+    public string UserName => "benchmark";
+    public IEnumerable<QueryParameter> DefaultQueryParameters => Enumerable.Empty<QueryParameter>();
+}
+
+public class NoOpEventNotifier : IEventNotifier
+{
+    public void RequestCaptured(Request request) { }
+    public void SubscriptionRegistered(Subscription subscription) { }
+    public void SubscriptionRemoved(Subscription subscription) { }
+}
+
+public static class BenchmarkConstants
+{
+    public static IOptions<Constants> Create(int maxEventsPerCall = 10000)
+    {
+        return Options.Create(new Constants
+        {
+            MaxEventsCapturePerCall = maxEventsPerCall,
+            MaxEventsReturnedInQuery = 20000,
+            CaptureSizeLimit = 1024
+        });
+    }
+
+    public static IOptions<Constants> CreateForQueries(int maxEventsReturned = 60000)
+    {
+        return Options.Create(new Constants
+        {
+            MaxEventsCapturePerCall = 10000,
+            MaxEventsReturnedInQuery = maxEventsReturned,
+            CaptureSizeLimit = 1024
+        });
+    }
+}

--- a/tests/FasTnT.PerformanceTests/Helpers/BenchmarkDbContext.cs
+++ b/tests/FasTnT.PerformanceTests/Helpers/BenchmarkDbContext.cs
@@ -1,0 +1,147 @@
+using FasTnT.Application.Database;
+using FasTnT.Sqlite;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace FasTnT.PerformanceTests.Helpers;
+
+public static class BenchmarkDbContext
+{
+    /// <summary>
+    /// Creates an EpcisContext configured with SQLite for benchmarking.
+    /// </summary>
+    /// <param name="databaseName">Name of the database. Use ":memory:" for in-memory database.</param>
+    /// <param name="useInMemory">If true, uses in-memory database. Otherwise, creates a file-based database.</param>
+    /// <returns>Configured EpcisContext ready for benchmarking.</returns>
+    public static EpcisContext CreateContext(string databaseName, bool useInMemory = false)
+    {
+        var connectionString = useInMemory
+            ? "DataSource=:memory:"
+            : $"DataSource={databaseName}.db";
+
+        var connection = new SqliteConnection(connectionString);
+
+        // For in-memory databases, keep connection open
+        if (useInMemory)
+        {
+            connection.Open();
+        }
+
+        var options = new DbContextOptionsBuilder<EpcisContext>()
+            .UseSqlite(connection, x =>
+            {
+                x.MigrationsAssembly(typeof(SqliteProvider).Assembly.FullName);
+                x.CommandTimeout(300); // 5 minutes timeout for large operations
+            })
+            .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
+            .Options;
+
+        var context = new EpcisContext(options);
+
+        // Apply migrations
+        context.Database.Migrate();
+
+        return context;
+    }
+
+    /// <summary>
+    /// Creates an in-memory EpcisContext for benchmarking.
+    /// </summary>
+    /// <param name="databaseName">Unique name for the in-memory database.</param>
+    /// <returns>Configured EpcisContext with in-memory database.</returns>
+    public static EpcisContext CreateInMemoryContext(string databaseName)
+    {
+        return CreateContext(databaseName, useInMemory: true);
+    }
+
+    /// <summary>
+    /// Creates a file-based EpcisContext for benchmarking.
+    /// </summary>
+    /// <param name="databaseName">Name of the database file (without extension).</param>
+    /// <returns>Configured EpcisContext with file-based database.</returns>
+    public static EpcisContext CreateFileContext(string databaseName)
+    {
+        return CreateContext(databaseName, useInMemory: false);
+    }
+
+    /// <summary>
+    /// Cleans up database resources.
+    /// </summary>
+    /// <param name="context">The context to clean up.</param>
+    /// <param name="deleteFile">If true, deletes the database file.</param>
+    public static void Cleanup(EpcisContext context, bool deleteFile = false)
+    {
+        var connection = context.Database.GetDbConnection();
+        var filePath = connection.DataSource;
+
+        context.Dispose();
+        connection.Dispose();
+
+        if (deleteFile && filePath != ":memory:" && File.Exists(filePath))
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    /// <summary>
+    /// Clears all data from the database without dropping the schema.
+    /// </summary>
+    /// <param name="context">The context to clear.</param>
+    public static async Task ClearDataAsync(EpcisContext context)
+    {
+        await using var transaction = await context.Database.BeginTransactionAsync();
+        try
+        {
+            // Disable foreign key checks during cleanup
+            await context.Database.ExecuteSqlRawAsync("PRAGMA foreign_keys=OFF");
+
+            // Delete all tables in dependency-safe order
+            // Child tables of Event (owned entities)
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM Epc");
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM Source");
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM Destination");
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM BusinessTransaction");
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM PersistentDisposition");
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM SensorElement");
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM SensorReport");
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM Field");
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM CorrectiveEventId");
+
+            // Child tables of MasterData (owned entities)
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM MasterDataField");
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM MasterDataAttribute");
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM MasterDataChildren");
+
+            // Child tables of StandardBusinessHeader (owned entities)
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM ContactInformation");
+
+            // Child tables of Subscription (owned entities)
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM SubscriptionParameter");
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM SubscriptionSchedule");
+
+            // Child tables of StoredQuery (owned entities)
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM StoredQueryParameter");
+
+            // Parent tables - delete in reverse dependency order
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM Event");
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM MasterData");
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM StandardBusinessHeader");
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM SubscriptionCallback");
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM Subscription");
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM StoredQuery");
+            await context.Database.ExecuteSqlRawAsync("DELETE FROM Request");
+
+            await transaction.CommitAsync();
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
+        finally
+        {
+            // Re-enable foreign key checks
+            await context.Database.ExecuteSqlRawAsync("PRAGMA foreign_keys=ON");
+        }
+    }
+}

--- a/tests/FasTnT.PerformanceTests/Helpers/TestDataGenerator.cs
+++ b/tests/FasTnT.PerformanceTests/Helpers/TestDataGenerator.cs
@@ -1,0 +1,805 @@
+using System.Text;
+using System.Text.Json;
+using FasTnT.Application.Database;
+using FasTnT.Domain.Enumerations;
+using FasTnT.Domain.Model;
+using FasTnT.Domain.Model.Events;
+using FasTnT.Domain.Model.Masterdata;
+using FasTnT.Domain.Model.Queries;
+using FasTnT.Domain.Model.Subscriptions;
+
+namespace FasTnT.PerformanceTests.Helpers;
+
+public static class TestDataGenerator
+{
+    private static readonly Random Random = new(42); // Fixed seed for reproducibility
+
+    public enum DataSize
+    {
+        Small,    // 100 events, 10 EPCs each
+        Medium,   // 500 events, 20 EPCs each
+        Large,    // 1000 events, 50 EPCs each
+        XLarge    // 5000 events, 100 EPCs each
+    }
+
+    public static (int eventCount, int epcsPerEvent) GetPresetConfiguration(DataSize size)
+    {
+        return size switch
+        {
+            DataSize.Small => (100, 10),
+            DataSize.Medium => (500, 20),
+            DataSize.Large => (1000, 50),
+            DataSize.XLarge => (5000, 100),
+            _ => throw new ArgumentOutOfRangeException(nameof(size))
+        };
+    }
+
+    /// <summary>
+    /// Generates an EPCIS 2.0 XML capture request with specified number of events.
+    /// </summary>
+    public static string GenerateXmlRequest(int eventCount, int epcsPerEvent)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        sb.AppendLine("<epcis:EPCISDocument xmlns:epcis=\"urn:epcglobal:epcis:xsd:2\" schemaVersion=\"2.0\" creationDate=\"2025-01-15T10:30:00Z\">");
+        sb.AppendLine("  <EPCISHeader/>");
+        sb.AppendLine("  <EPCISBody>");
+        sb.AppendLine("    <EventList>");
+
+        for (int i = 0; i < eventCount; i++)
+        {
+            sb.AppendLine(GenerateXmlObjectEvent(epcsPerEvent, i));
+        }
+
+        sb.AppendLine("    </EventList>");
+        sb.AppendLine("  </EPCISBody>");
+        sb.AppendLine("</epcis:EPCISDocument>");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Generates an EPCIS 2.0 JSON capture request with specified number of events.
+    /// </summary>
+    public static string GenerateJsonRequest(int eventCount, int epcsPerEvent)
+    {
+        var events = new List<object>();
+
+        for (int i = 0; i < eventCount; i++)
+        {
+            events.Add(GenerateJsonObjectEvent(epcsPerEvent, i));
+        }
+
+        var document = new
+        {
+            type = "EPCISDocument",
+            schemaVersion = "2.0",
+            creationDate = "2025-01-15T10:30:00Z",
+            epcisHeader = new { },
+            epcisBody = new
+            {
+                eventList = events
+            }
+        };
+
+        return JsonSerializer.Serialize(document, new JsonSerializerOptions
+        {
+            WriteIndented = false
+        });
+    }
+
+    /// <summary>
+    /// Generates an EPCIS 2.0 XML capture request with mixed event types (ObjectEvent, AggregationEvent, TransformationEvent).
+    /// Event distribution: 70% ObjectEvents, 20% AggregationEvents, 10% TransformationEvents.
+    /// </summary>
+    public static string GenerateXmlMixedRequest(int eventCount, int epcsPerEvent)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        sb.AppendLine("<epcis:EPCISDocument xmlns:epcis=\"urn:epcglobal:epcis:xsd:2\" schemaVersion=\"2.0\" creationDate=\"2025-01-15T10:30:00Z\">");
+        sb.AppendLine("  <EPCISHeader/>");
+        sb.AppendLine("  <EPCISBody>");
+        sb.AppendLine("    <EventList>");
+
+        var objectEventCount = (int)(eventCount * 0.7);  // 70% ObjectEvents
+        var aggregationEventCount = (int)(eventCount * 0.2);  // 20% AggregationEvents
+        var transformationEventCount = eventCount - objectEventCount - aggregationEventCount;  // 10% TransformationEvents
+
+        int currentIndex = 0;
+
+        // Generate ObjectEvents
+        for (int i = 0; i < objectEventCount; i++)
+        {
+            sb.AppendLine(GenerateXmlObjectEvent(epcsPerEvent, currentIndex++));
+        }
+
+        // Generate AggregationEvents
+        for (int i = 0; i < aggregationEventCount; i++)
+        {
+            sb.AppendLine(GenerateXmlAggregationEvent(epcsPerEvent, currentIndex++));
+        }
+
+        // Generate TransformationEvents
+        for (int i = 0; i < transformationEventCount; i++)
+        {
+            sb.AppendLine(GenerateXmlTransformationEvent(epcsPerEvent / 2, epcsPerEvent / 2, currentIndex++));
+        }
+
+        sb.AppendLine("    </EventList>");
+        sb.AppendLine("  </EPCISBody>");
+        sb.AppendLine("</epcis:EPCISDocument>");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Generates an EPCIS 2.0 JSON capture request with mixed event types (ObjectEvent, AggregationEvent, TransformationEvent).
+    /// Event distribution: 70% ObjectEvents, 20% AggregationEvents, 10% TransformationEvents.
+    /// </summary>
+    public static string GenerateJsonMixedRequest(int eventCount, int epcsPerEvent)
+    {
+        var events = new List<object>();
+
+        var objectEventCount = (int)(eventCount * 0.7);  // 70% ObjectEvents
+        var aggregationEventCount = (int)(eventCount * 0.2);  // 20% AggregationEvents
+        var transformationEventCount = eventCount - objectEventCount - aggregationEventCount;  // 10% TransformationEvents
+
+        int currentIndex = 0;
+
+        // Generate ObjectEvents
+        for (int i = 0; i < objectEventCount; i++)
+        {
+            events.Add(GenerateJsonObjectEvent(epcsPerEvent, currentIndex++));
+        }
+
+        // Generate AggregationEvents
+        for (int i = 0; i < aggregationEventCount; i++)
+        {
+            events.Add(GenerateJsonAggregationEvent(epcsPerEvent, currentIndex++));
+        }
+
+        // Generate TransformationEvents
+        for (int i = 0; i < transformationEventCount; i++)
+        {
+            events.Add(GenerateJsonTransformationEvent(epcsPerEvent / 2, epcsPerEvent / 2, currentIndex++));
+        }
+
+        var document = new
+        {
+            type = "EPCISDocument",
+            schemaVersion = "2.0",
+            creationDate = "2025-01-15T10:30:00Z",
+            epcisHeader = new { },
+            epcisBody = new
+            {
+                eventList = events
+            }
+        };
+
+        return JsonSerializer.Serialize(document, new JsonSerializerOptions
+        {
+            WriteIndented = false
+        });
+    }
+
+    /// <summary>
+    /// Generates a single XML ObjectEvent.
+    /// </summary>
+    private static string GenerateXmlObjectEvent(int epcCount, int eventIndex)
+    {
+        var eventTime = DateTime.UtcNow.AddMinutes(-eventIndex);
+        var sb = new StringBuilder();
+
+        sb.AppendLine("      <ObjectEvent>");
+        sb.AppendLine($"        <eventTime>{eventTime:yyyy-MM-ddTHH:mm:ss}Z</eventTime>");
+        sb.AppendLine("        <eventTimeZoneOffset>+00:00</eventTimeZoneOffset>");
+        sb.AppendLine("        <epcList>");
+
+        for (int i = 0; i < epcCount; i++)
+        {
+            sb.AppendLine($"          <epc>{GenerateRandomEpc(eventIndex, i)}</epc>");
+        }
+
+        sb.AppendLine("        </epcList>");
+        sb.AppendLine("        <action>OBSERVE</action>");
+        sb.AppendLine("        <bizStep>urn:epcglobal:cbv:bizstep:receiving</bizStep>");
+        sb.AppendLine("        <disposition>urn:epcglobal:cbv:disp:in_progress</disposition>");
+        sb.AppendLine($"        <readPoint><id>urn:epc:id:sgln:8901213.00001.{eventIndex % 100}</id></readPoint>");
+        sb.AppendLine($"        <bizLocation><id>urn:epc:id:sgln:8901213.00002.{eventIndex % 50}</id></bizLocation>");
+        sb.AppendLine("      </ObjectEvent>");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Generates a single JSON ObjectEvent.
+    /// </summary>
+    private static object GenerateJsonObjectEvent(int epcCount, int eventIndex)
+    {
+        var eventTime = DateTime.UtcNow.AddMinutes(-eventIndex);
+        var epcs = new List<string>();
+
+        for (int i = 0; i < epcCount; i++)
+        {
+            epcs.Add(GenerateRandomEpc(eventIndex, i));
+        }
+
+        return new
+        {
+            type = "ObjectEvent",
+            eventTime = eventTime.ToString("yyyy-MM-ddTHH:mm:ss") + "Z",
+            eventTimeZoneOffset = "+00:00",
+            epcList = epcs,
+            action = "OBSERVE",
+            bizStep = "urn:epcglobal:cbv:bizstep:receiving",
+            disposition = "urn:epcglobal:cbv:disp:in_progress",
+            readPoint = new { id = $"urn:epc:id:sgln:8901213.00001.{eventIndex % 100}" },
+            bizLocation = new { id = $"urn:epc:id:sgln:8901213.00002.{eventIndex % 50}" }
+        };
+    }
+
+    /// <summary>
+    /// Generates a single XML AggregationEvent.
+    /// </summary>
+    private static string GenerateXmlAggregationEvent(int childEpcCount, int eventIndex)
+    {
+        var eventTime = DateTime.UtcNow.AddMinutes(-eventIndex);
+        var parentId = $"urn:epc:id:sscc:8901213.0000{eventIndex % 1000:D6}";
+        var sb = new StringBuilder();
+
+        sb.AppendLine("      <AggregationEvent>");
+        sb.AppendLine($"        <eventTime>{eventTime:yyyy-MM-ddTHH:mm:ss}Z</eventTime>");
+        sb.AppendLine("        <eventTimeZoneOffset>+00:00</eventTimeZoneOffset>");
+        sb.AppendLine($"        <parentID>{parentId}</parentID>");
+        sb.AppendLine("        <childEPCs>");
+
+        for (int i = 0; i < childEpcCount; i++)
+        {
+            sb.AppendLine($"          <epc>{GenerateRandomEpc(eventIndex, i)}</epc>");
+        }
+
+        sb.AppendLine("        </childEPCs>");
+        sb.AppendLine("        <action>ADD</action>");
+        sb.AppendLine("        <bizStep>urn:epcglobal:cbv:bizstep:packing</bizStep>");
+        sb.AppendLine("        <disposition>urn:epcglobal:cbv:disp:in_progress</disposition>");
+        sb.AppendLine($"        <readPoint><id>urn:epc:id:sgln:8901213.00001.{eventIndex % 100}</id></readPoint>");
+        sb.AppendLine($"        <bizLocation><id>urn:epc:id:sgln:8901213.00002.{eventIndex % 50}</id></bizLocation>");
+        sb.AppendLine("      </AggregationEvent>");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Generates a single JSON AggregationEvent.
+    /// </summary>
+    private static object GenerateJsonAggregationEvent(int childEpcCount, int eventIndex)
+    {
+        var eventTime = DateTime.UtcNow.AddMinutes(-eventIndex);
+        var parentId = $"urn:epc:id:sscc:8901213.0000{eventIndex % 1000:D6}";
+        var childEpcs = new List<string>();
+
+        for (int i = 0; i < childEpcCount; i++)
+        {
+            childEpcs.Add(GenerateRandomEpc(eventIndex, i));
+        }
+
+        return new
+        {
+            type = "AggregationEvent",
+            eventTime = eventTime.ToString("yyyy-MM-ddTHH:mm:ss") + "Z",
+            eventTimeZoneOffset = "+00:00",
+            parentID = parentId,
+            childEPCs = childEpcs,
+            action = "ADD",
+            bizStep = "urn:epcglobal:cbv:bizstep:packing",
+            disposition = "urn:epcglobal:cbv:disp:in_progress",
+            readPoint = new { id = $"urn:epc:id:sgln:8901213.00001.{eventIndex % 100}" },
+            bizLocation = new { id = $"urn:epc:id:sgln:8901213.00002.{eventIndex % 50}" }
+        };
+    }
+
+    /// <summary>
+    /// Generates a single XML TransformationEvent.
+    /// </summary>
+    private static string GenerateXmlTransformationEvent(int inputEpcCount, int outputEpcCount, int eventIndex)
+    {
+        var eventTime = DateTime.UtcNow.AddMinutes(-eventIndex);
+        var sb = new StringBuilder();
+
+        sb.AppendLine("      <TransformationEvent>");
+        sb.AppendLine($"        <eventTime>{eventTime:yyyy-MM-ddTHH:mm:ss}Z</eventTime>");
+        sb.AppendLine("        <eventTimeZoneOffset>+00:00</eventTimeZoneOffset>");
+        sb.AppendLine("        <inputEPCList>");
+
+        for (int i = 0; i < inputEpcCount; i++)
+        {
+            sb.AppendLine($"          <epc>{GenerateRandomEpc(eventIndex, i)}</epc>");
+        }
+
+        sb.AppendLine("        </inputEPCList>");
+        sb.AppendLine("        <outputEPCList>");
+
+        for (int i = 0; i < outputEpcCount; i++)
+        {
+            sb.AppendLine($"          <epc>{GenerateRandomEpc(eventIndex, inputEpcCount + i)}</epc>");
+        }
+
+        sb.AppendLine("        </outputEPCList>");
+        sb.AppendLine("        <bizStep>urn:epcglobal:cbv:bizstep:commissioning</bizStep>");
+        sb.AppendLine("        <disposition>urn:epcglobal:cbv:disp:in_progress</disposition>");
+        sb.AppendLine($"        <readPoint><id>urn:epc:id:sgln:8901213.00001.{eventIndex % 100}</id></readPoint>");
+        sb.AppendLine($"        <bizLocation><id>urn:epc:id:sgln:8901213.00002.{eventIndex % 50}</id></bizLocation>");
+        sb.AppendLine("      </TransformationEvent>");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Generates a single JSON TransformationEvent.
+    /// </summary>
+    private static object GenerateJsonTransformationEvent(int inputEpcCount, int outputEpcCount, int eventIndex)
+    {
+        var eventTime = DateTime.UtcNow.AddMinutes(-eventIndex);
+        var inputEpcs = new List<string>();
+        var outputEpcs = new List<string>();
+
+        for (int i = 0; i < inputEpcCount; i++)
+        {
+            inputEpcs.Add(GenerateRandomEpc(eventIndex, i));
+        }
+
+        for (int i = 0; i < outputEpcCount; i++)
+        {
+            outputEpcs.Add(GenerateRandomEpc(eventIndex, inputEpcCount + i));
+        }
+
+        return new
+        {
+            type = "TransformationEvent",
+            eventTime = eventTime.ToString("yyyy-MM-ddTHH:mm:ss") + "Z",
+            eventTimeZoneOffset = "+00:00",
+            inputEPCList = inputEpcs,
+            outputEPCList = outputEpcs,
+            bizStep = "urn:epcglobal:cbv:bizstep:commissioning",
+            disposition = "urn:epcglobal:cbv:disp:in_progress",
+            readPoint = new { id = $"urn:epc:id:sgln:8901213.00001.{eventIndex % 100}" },
+            bizLocation = new { id = $"urn:epc:id:sgln:8901213.00002.{eventIndex % 50}" }
+        };
+    }
+
+    /// <summary>
+    /// Generates a valid SGTIN EPC URN.
+    /// </summary>
+    public static string GenerateRandomEpc(int eventIndex = 0, int epcIndex = 0)
+    {
+        var companyPrefix = "8901213";
+        var itemReference = $"{105919 + (eventIndex % 1000):D6}";
+        var serialNumber = $"{epcIndex:D6}";
+
+        return $"urn:epc:id:sgtin:{companyPrefix}.{itemReference}.{serialNumber}";
+    }
+
+    /// <summary>
+    /// Generates an ObjectEvent domain model.
+    /// </summary>
+    public static Event GenerateObjectEvent(int epcCount, int eventIndex = 0)
+    {
+        var eventTime = DateTime.UtcNow.AddMinutes(-eventIndex);
+        var epcs = new List<Epc>();
+
+        for (int i = 0; i < epcCount; i++)
+        {
+            epcs.Add(new Epc
+            {
+                Type = EpcType.List,
+                Id = GenerateRandomEpc(eventIndex, i)
+            });
+        }
+
+        return new Event
+        {
+            Type = EventType.ObjectEvent,
+            EventTime = eventTime,
+            EventTimeZoneOffset = "+00:00",
+            Action = EventAction.Observe,
+            BusinessStep = "urn:epcglobal:cbv:bizstep:receiving",
+            Disposition = "urn:epcglobal:cbv:disp:in_progress",
+            ReadPoint = $"urn:epc:id:sgln:8901213.00001.{eventIndex % 100}",
+            BusinessLocation = $"urn:epc:id:sgln:8901213.00002.{eventIndex % 50}",
+            Epcs = epcs
+        };
+    }
+
+    /// <summary>
+    /// Generates an AggregationEvent domain model.
+    /// </summary>
+    public static Event GenerateAggregationEvent(int childEpcCount, int eventIndex = 0)
+    {
+        var eventTime = DateTime.UtcNow.AddMinutes(-eventIndex);
+        var childEpcs = new List<Epc>();
+
+        for (int i = 0; i < childEpcCount; i++)
+        {
+            childEpcs.Add(new Epc
+            {
+                Type = EpcType.ChildEpc,
+                Id = GenerateRandomEpc(eventIndex, i)
+            });
+        }
+
+        var parentId = $"urn:epc:id:sscc:8901213.0000{eventIndex % 1000:D6}";
+
+        childEpcs.Add(new Epc
+        {
+            Type = EpcType.ParentId,
+            Id = parentId
+        });
+
+        return new Event
+        {
+            Type = EventType.AggregationEvent,
+            EventTime = eventTime,
+            EventTimeZoneOffset = "+00:00",
+            Action = EventAction.Add,
+            BusinessStep = "urn:epcglobal:cbv:bizstep:packing",
+            Disposition = "urn:epcglobal:cbv:disp:in_progress",
+            ReadPoint = $"urn:epc:id:sgln:8901213.00001.{eventIndex % 100}",
+            BusinessLocation = $"urn:epc:id:sgln:8901213.00002.{eventIndex % 50}",
+            Epcs = childEpcs
+        };
+    }
+
+    /// <summary>
+    /// Generates a TransformationEvent domain model.
+    /// </summary>
+    public static Event GenerateTransformationEvent(int inputEpcCount, int outputEpcCount, int eventIndex = 0)
+    {
+        var eventTime = DateTime.UtcNow.AddMinutes(-eventIndex);
+        var inputEpcs = new List<Epc>();
+        var outputEpcs = new List<Epc>();
+
+        for (int i = 0; i < inputEpcCount; i++)
+        {
+            inputEpcs.Add(new Epc
+            {
+                Type = EpcType.InputEpc,
+                Id = GenerateRandomEpc(eventIndex, i)
+            });
+        }
+
+        for (int i = 0; i < outputEpcCount; i++)
+        {
+            outputEpcs.Add(new Epc
+            {
+                Type = EpcType.OutputEpc,
+                Id = GenerateRandomEpc(eventIndex, inputEpcCount + i)
+            });
+        }
+
+        return new Event
+        {
+            Type = EventType.TransformationEvent,
+            EventTime = eventTime,
+            EventTimeZoneOffset = "+00:00",
+            BusinessStep = "urn:epcglobal:cbv:bizstep:commissioning",
+            Disposition = "urn:epcglobal:cbv:disp:in_progress",
+            ReadPoint = $"urn:epc:id:sgln:8901213.00001.{eventIndex % 100}",
+            BusinessLocation = $"urn:epc:id:sgln:8901213.00002.{eventIndex % 50}",
+            Epcs = inputEpcs.Concat(outputEpcs).ToList()
+        };
+    }
+
+    /// <summary>
+    /// Creates a Request object from a list of events.
+    /// </summary>
+    public static Request CreateRequestFromEvents(List<Event> events)
+    {
+        return new Request
+        {
+            DocumentTime = DateTime.UtcNow,
+            RecordTime = DateTime.UtcNow,
+            SchemaVersion = "2.0",
+            Events = events
+        };
+    }
+
+    /// <summary>
+    /// Generates a list of mixed event types.
+    /// </summary>
+    public static List<Event> GenerateMixedEvents(int totalCount, int epcsPerEvent = 10)
+    {
+        var events = new List<Event>();
+        var objectEventCount = (int)(totalCount * 0.7);  // 70% ObjectEvents
+        var aggregationEventCount = (int)(totalCount * 0.2);  // 20% AggregationEvents
+        var transformationEventCount = totalCount - objectEventCount - aggregationEventCount;  // 10% TransformationEvents
+
+        for (int i = 0; i < objectEventCount; i++)
+        {
+            events.Add(GenerateObjectEvent(epcsPerEvent, i));
+        }
+
+        for (int i = 0; i < aggregationEventCount; i++)
+        {
+            events.Add(GenerateAggregationEvent(epcsPerEvent, objectEventCount + i));
+        }
+
+        for (int i = 0; i < transformationEventCount; i++)
+        {
+            events.Add(GenerateTransformationEvent(epcsPerEvent / 2, epcsPerEvent / 2, objectEventCount + aggregationEventCount + i));
+        }
+
+        return events;
+    }
+
+    /// <summary>
+    /// Deep copies a Request and resets its Id, RecordTime, and EventId values to ensure
+    /// hashing and inserts execute every run, avoiding benchmark skew from reused instances.
+    /// </summary>
+    public static Request DeepCopyAndResetRequest(Request source)
+    {
+        var newRequest = new Request
+        {
+            Id = 0, // Reset Id for EF Core
+            CaptureId = source.CaptureId,
+            RecordTime = default, // Reset RecordTime
+            UserId = source.UserId,
+            StandardBusinessHeader = source.StandardBusinessHeader,
+            DocumentTime = source.DocumentTime == default ? DateTime.UtcNow : source.DocumentTime,
+            SchemaVersion = string.IsNullOrEmpty(source.SchemaVersion) ? "2.0" : source.SchemaVersion,
+            SubscriptionCallback = source.SubscriptionCallback,
+            Events = new List<Event>(),
+            Masterdata = new List<MasterData>()
+        };
+
+        foreach (var evt in source.Events)
+        {
+            var newEvent = new Event
+            {
+                Id = 0, // Reset Id for EF Core
+                EventTime = evt.EventTime,
+                EventTimeZoneOffset = evt.EventTimeZoneOffset,
+                Type = evt.Type,
+                Action = evt.Action,
+                EventId = null, // Reset EventId to force rehashing
+                CertificationInfo = evt.CertificationInfo,
+                ReadPoint = evt.ReadPoint,
+                BusinessLocation = evt.BusinessLocation,
+                BusinessStep = evt.BusinessStep,
+                Disposition = evt.Disposition,
+                TransformationId = evt.TransformationId,
+                CorrectiveDeclarationTime = evt.CorrectiveDeclarationTime,
+                CorrectiveReason = evt.CorrectiveReason,
+                CorrectiveEventIds = evt.CorrectiveEventIds.Select(cei => new CorrectiveEventId
+                {
+                    CorrectiveId = cei.CorrectiveId
+                }).ToList(),
+                Epcs = evt.Epcs.Select(epc => new Epc
+                {
+                    Type = epc.Type,
+                    Id = epc.Id,
+                    Quantity = epc.Quantity,
+                    UnitOfMeasure = epc.UnitOfMeasure
+                }).ToList(),
+                Transactions = evt.Transactions.Select(t => new BusinessTransaction
+                {
+                    Type = t.Type,
+                    Id = t.Id
+                }).ToList(),
+                Sources = evt.Sources.Select(s => new Source
+                {
+                    Type = s.Type,
+                    Id = s.Id
+                }).ToList(),
+                Destinations = evt.Destinations.Select(d => new Destination
+                {
+                    Type = d.Type,
+                    Id = d.Id
+                }).ToList(),
+                SensorElements = evt.SensorElements.Select(se => new SensorElement
+                {
+                    Index = se.Index,
+                    Time = se.Time,
+                    DeviceId = se.DeviceId,
+                    DeviceMetadata = se.DeviceMetadata,
+                    RawData = se.RawData,
+                    StartTime = se.StartTime,
+                    EndTime = se.EndTime,
+                    DataProcessingMethod = se.DataProcessingMethod,
+                    BizRules = se.BizRules
+                }).ToList(),
+                Reports = evt.Reports.Select(r => new SensorReport
+                {
+                    Index = r.Index,
+                    SensorIndex = r.SensorIndex,
+                    Type = r.Type,
+                    DeviceId = r.DeviceId,
+                    DeviceMetadata = r.DeviceMetadata,
+                    RawData = r.RawData,
+                    DataProcessingMethod = r.DataProcessingMethod,
+                    Time = r.Time,
+                    Microorganism = r.Microorganism,
+                    ChemicalSubstance = r.ChemicalSubstance,
+                    Value = r.Value,
+                    Component = r.Component,
+                    StringValue = r.StringValue,
+                    BooleanValue = r.BooleanValue,
+                    HexBinaryValue = r.HexBinaryValue,
+                    UriValue = r.UriValue,
+                    MinValue = r.MinValue,
+                    MaxValue = r.MaxValue,
+                    MeanValue = r.MeanValue,
+                    SDev = r.SDev,
+                    PercRank = r.PercRank,
+                    PercValue = r.PercValue,
+                    UnitOfMeasure = r.UnitOfMeasure,
+                    CoordinateReferenceSystem = r.CoordinateReferenceSystem
+                }).ToList(),
+                PersistentDispositions = evt.PersistentDispositions.Select(pd => new PersistentDisposition
+                {
+                    Type = pd.Type,
+                    Id = pd.Id
+                }).ToList(),
+                Fields = evt.Fields.Select(f => new Field
+                {
+                    Type = f.Type,
+                    Name = f.Name,
+                    Namespace = f.Namespace,
+                    TextValue = f.TextValue,
+                    NumericValue = f.NumericValue,
+                    DateValue = f.DateValue,
+                    Index = f.Index,
+                    EntityIndex = f.EntityIndex,
+                    ParentIndex = f.ParentIndex
+                }).ToList()
+            };
+
+            newRequest.Events.Add(newEvent);
+        }
+
+        return newRequest;
+    }
+
+    /// <summary>
+    /// Populates a database with mixed events for query benchmarks.
+    /// </summary>
+    public static void PopulateDatabaseWithEvents(EpcisContext context, int eventCount)
+    {
+        var bizSteps = new[]
+        {
+            "urn:epcglobal:cbv:bizstep:receiving",
+            "urn:epcglobal:cbv:bizstep:shipping",
+            "urn:epcglobal:cbv:bizstep:packing",
+            "urn:epcglobal:cbv:bizstep:commissioning",
+            "urn:epcglobal:cbv:bizstep:accepting"
+        };
+
+        var dispositions = new[]
+        {
+            "urn:epcglobal:cbv:disp:in_progress",
+            "urn:epcglobal:cbv:disp:in_transit",
+            "urn:epcglobal:cbv:disp:active",
+            "urn:epcglobal:cbv:disp:dispensed",
+            "urn:epcglobal:cbv:disp:destroyed"
+        };
+
+        var events = new List<Event>();
+        var objectEventCount = (int)(eventCount * 0.7);
+        var aggregationEventCount = (int)(eventCount * 0.2);
+        var transformationEventCount = eventCount - objectEventCount - aggregationEventCount;
+
+        // Generate ObjectEvents with varying business steps and dispositions
+        for (int i = 0; i < objectEventCount; i++)
+        {
+            var evt = GenerateObjectEvent(10, i);
+            evt.BusinessStep = bizSteps[i % bizSteps.Length];
+            evt.Disposition = dispositions[i % dispositions.Length];
+            evt.ReadPoint = $"urn:epc:id:sgln:0614141.07346.{i % 100}";
+            evt.BusinessLocation = $"urn:epc:id:sgln:0614141.07346.{i % 50}";
+            events.Add(evt);
+        }
+
+        // Generate AggregationEvents
+        for (int i = 0; i < aggregationEventCount; i++)
+        {
+            var evt = GenerateAggregationEvent(10, objectEventCount + i);
+            evt.BusinessStep = bizSteps[i % bizSteps.Length];
+            evt.Disposition = dispositions[i % dispositions.Length];
+            events.Add(evt);
+        }
+
+        // Generate TransformationEvents
+        for (int i = 0; i < transformationEventCount; i++)
+        {
+            var evt = GenerateTransformationEvent(5, 5, objectEventCount + aggregationEventCount + i);
+            evt.BusinessStep = bizSteps[i % bizSteps.Length];
+            evt.Disposition = dispositions[i % dispositions.Length];
+            events.Add(evt);
+        }
+
+        var request = CreateRequestFromEvents(events);
+        context.Add(request);
+        context.SaveChanges();
+    }
+
+    /// <summary>
+    /// Generates events with custom extension fields.
+    /// </summary>
+    public static List<Event> GenerateEventsWithCustomFields(int count)
+    {
+        var events = GenerateMixedEvents(count);
+        var namespaces = new[]
+        {
+            "http://example.com/epcis/extension1",
+            "http://example.com/epcis/extension2",
+            "http://company.org/custom"
+        };
+
+        foreach (var evt in events)
+        {
+            var fieldCount = Random.Next(3, 8);
+            evt.Fields = new List<Field>();
+
+            for (int i = 0; i < fieldCount; i++)
+            {
+                evt.Fields.Add(new Field
+                {
+                    Type = FieldType.CustomField,
+                    Namespace = namespaces[i % namespaces.Length],
+                    Name = $"customField{i}",
+                    TextValue = $"value_{i}_{Random.Next(1000)}",
+                    Index = i
+                });
+            }
+        }
+
+        return events;
+    }
+
+    /// <summary>
+    /// Generates events with sensor elements and reports.
+    /// </summary>
+    public static List<Event> GenerateEventsWithSensorData(int count)
+    {
+        var events = GenerateMixedEvents(count);
+
+        foreach (var evt in events)
+        {
+            var sensorElement = new SensorElement
+            {
+                Index = 0,
+                DeviceId = $"urn:epc:id:giai:4000001.{Random.Next(1000, 9999)}",
+                DeviceMetadata = "urn:epcglobal:cbv:sdt:temperature_sensor",
+                RawData = "https://example.com/sensor/data",
+                StartTime = evt.EventTime.AddMinutes(-10),
+                EndTime = evt.EventTime,
+                DataProcessingMethod = "https://example.com/sensor/processing"
+            };
+
+            var report = new SensorReport
+            {
+                Index = 0,
+                SensorIndex = 0,
+                Type = "Temperature",
+                UnitOfMeasure = "CEL",
+                Value = 20 + Random.Next(-5, 15),
+                MinValue = 15,
+                MaxValue = 25,
+                MeanValue = 20,
+                Time = evt.EventTime
+            };
+
+            evt.SensorElements = new List<SensorElement> { sensorElement };
+            evt.Reports = new List<SensorReport> { report };
+        }
+
+        return events;
+    }
+
+    /// <summary>
+    /// Creates a QueryResponse from a list of events.
+    /// </summary>
+    public static QueryResponse CreateQueryResponse(List<Event> events, string queryName = "SimpleEventQuery")
+    {
+        return new QueryResponse(queryName, new QueryData { EventList = events });
+    }
+}

--- a/tests/FasTnT.PerformanceTests/Program.cs
+++ b/tests/FasTnT.PerformanceTests/Program.cs
@@ -1,0 +1,34 @@
+using BenchmarkDotNet.Running;
+using FasTnT.PerformanceTests.Config;
+
+namespace FasTnT.PerformanceTests;
+
+/// <summary>
+/// FasTnT EPCIS Performance Test Suite
+///
+/// Run all benchmarks:
+///   dotnet run -c Release
+///
+/// Run specific benchmark categories:
+///   dotnet run -c Release --filter *QueryBenchmarks*
+///   dotnet run -c Release --filter *SerializationBenchmarks*
+///   dotnet run -c Release --filter *EndToEndQueryBenchmarks*
+///   dotnet run -c Release --filter *CaptureBenchmarks*
+///
+/// Run specific benchmark methods:
+///   dotnet run -c Release --filter *QueryByEpc*
+///   dotnet run -c Release --filter *SerializeToXml*
+///
+/// Additional BenchmarkDotNet options:
+///   --join                    Join multiple benchmark results
+///   --memory                  Enable memory diagnoser
+///   --list                    List all available benchmarks
+///   --artifacts               Specify artifacts directory
+/// </summary>
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    }
+}

--- a/tests/FasTnT.PerformanceTests/README.md
+++ b/tests/FasTnT.PerformanceTests/README.md
@@ -1,0 +1,309 @@
+# FasTnT Performance Tests
+
+This project contains performance benchmarks for the FasTnT EPCIS implementation using BenchmarkDotNet.
+
+## Purpose
+
+The performance tests are designed to:
+- Measure execution time and memory allocation for critical operations
+- Identify performance bottlenecks in capture and query endpoints
+- Track performance regressions across code changes
+- Provide concrete metrics for optimization efforts
+- Test system behavior with large EPCIS documents
+
+## Running Benchmarks
+
+### Run All Benchmarks
+
+```bash
+dotnet run -c Release --project tests/FasTnT.PerformanceTests
+```
+
+**Important**: Always run benchmarks in Release mode for accurate results.
+
+### Run Specific Benchmarks
+
+Use filters to run specific benchmark classes or methods:
+
+```bash
+# Run all benchmarks in a specific class
+dotnet run -c Release --project tests/FasTnT.PerformanceTests --filter *CaptureBenchmarks*
+
+# Run a specific benchmark method
+dotnet run -c Release --project tests/FasTnT.PerformanceTests --filter *CaptureBenchmarks.CaptureSmallDocument*
+```
+
+### Run with Custom Configuration
+
+```bash
+# Run with specific job
+dotnet run -c Release --project tests/FasTnT.PerformanceTests -- --job short
+
+# Run with memory profiler
+dotnet run -c Release --project tests/FasTnT.PerformanceTests -- --memory
+```
+
+## Understanding Results
+
+### Key Metrics
+
+| Metric | Description |
+|--------|-------------|
+| **Mean** | Arithmetic average of all measurements |
+| **Error** | Half of 99.9% confidence interval |
+| **StdDev** | Standard deviation of all measurements |
+| **Median** | Value separating the higher half from the lower half |
+| **Allocated** | Total memory allocated per operation |
+| **Gen0/Gen1/Gen2** | Number of garbage collections per 1000 operations |
+
+### Example Output
+
+```
+|                Method |     Mean |    Error |   StdDev | Allocated |
+|---------------------- |---------:|---------:|---------:|----------:|
+| CaptureSmallDocument  | 45.23 ms | 0.892 ms | 0.835 ms |  12.45 MB |
+| CaptureLargeDocument  | 523.1 ms | 10.24 ms | 9.576 ms | 145.23 MB |
+```
+
+### Interpreting Results
+
+- **Lower is better** for Mean, Error, StdDev, and Allocated
+- **Consistency matters**: Lower StdDev indicates more predictable performance
+- **Memory allocations**: High allocations may indicate opportunities for optimization
+- **Gen2 collections**: Should be minimal for good performance
+
+## Report Locations
+
+After running benchmarks, reports are generated in:
+
+```
+tests/FasTnT.PerformanceTests/BenchmarkDotNet.Artifacts/results/
+```
+
+Available formats:
+- **HTML**: Interactive report with charts (`*-report.html`)
+- **Markdown**: GitHub-friendly format (`*-report-github.md`)
+- **CSV**: Raw data for analysis (`*-report.csv`)
+
+## Capture Endpoint Benchmarks
+
+The project includes comprehensive benchmarks for the EPCIS capture endpoint:
+
+### XmlParsingBenchmarks
+Measures XML document parsing performance across different scales:
+- Tests: 100 to 10,000 events with varying EPC counts (10, 50, 100 per event)
+- Includes: XML schema validation overhead
+- Purpose: Identify XML parsing bottlenecks and memory allocations
+
+### JsonParsingBenchmarks
+Measures JSON document parsing performance:
+- Tests: Same scale as XML (100-10,000 events)
+- Includes: Both full document parsing and individual event parsing
+- Purpose: Compare JSON vs XML parsing efficiency
+
+### CaptureBenchmarks (End-to-End)
+Measures complete capture pipeline from parsing to database storage:
+- `CaptureXmlEndToEnd()`: Full XML capture flow
+- `CaptureJsonEndToEnd()`: Full JSON capture flow
+- `CapturePreParsedRequest()`: Validation + hashing + database (no parsing)
+- `CaptureWithAggregations()`: Parent-child EPC relationship handling
+- Purpose: Identify end-to-end bottlenecks and format comparison
+
+### ComponentBenchmarks
+Isolates individual component performance:
+- `ValidateRequest()`: Request validation overhead
+- `ValidateEvents()`: Per-event validation by event type
+- `ComputeEventHashes()`: Event hash computation overhead
+- `DatabaseInsertOnly()`: Raw EF Core insert performance
+- `DatabaseInsertWithTransaction()`: Transaction overhead measurement
+- `DatabaseBulkInsert()`: Batch insert vs single large request
+- Purpose: Pinpoint specific bottlenecks in the pipeline
+
+### StressTestBenchmarks
+Tests system behavior under extreme conditions:
+- `CaptureAtMaxLimit()`: Performance at production limit (500 events)
+- `CaptureExceedingLimit()`: Validation rejection speed for oversized requests
+- `CaptureLargeXmlDocument()`: 5,000-10,000 event XML documents
+- `CaptureLargeJsonDocument()`: 5,000-10,000 event JSON documents
+- `CaptureRealisticMixedWorkload()`: Mixed event types with varying EPC counts
+- Purpose: Identify scalability limits and degradation patterns
+
+### Running Capture Benchmarks
+
+```bash
+# Run all capture benchmarks
+dotnet run -c Release --project tests/FasTnT.PerformanceTests
+
+# Run specific benchmark classes
+dotnet run -c Release --project tests/FasTnT.PerformanceTests --filter *XmlParsingBenchmarks*
+dotnet run -c Release --project tests/FasTnT.PerformanceTests --filter *JsonParsingBenchmarks*
+dotnet run -c Release --project tests/FasTnT.PerformanceTests --filter *CaptureBenchmarks*
+dotnet run -c Release --project tests/FasTnT.PerformanceTests --filter *ComponentBenchmarks*
+dotnet run -c Release --project tests/FasTnT.PerformanceTests --filter *StressTestBenchmarks*
+
+# Run specific benchmark method
+dotnet run -c Release --project tests/FasTnT.PerformanceTests --filter *CaptureBenchmarks.CapturePreParsedRequest*
+```
+
+## Analyzing Capture Performance
+
+### Expected Bottlenecks
+
+Based on code analysis, likely performance issues:
+
+1. **XML Schema Validation**: XSD validation in XML parsing
+2. **JSON Schema Validation**: JSON schema validation overhead
+3. **Database Transaction**: Single transaction for entire capture
+4. **Double SaveChanges**: Called twice per capture (insert + record time update)
+5. **Event Hash Computation**: Computed for all events without IDs
+
+### Interpreting Results
+
+**Parsing Performance:**
+- Compare XML vs JSON parsing times
+- Higher memory allocations in XML indicate schema validation overhead
+- JSON should generally be faster due to simpler validation
+
+**End-to-End Performance:**
+- If `CapturePreParsedRequest` is fast but `CaptureXmlEndToEnd` is slow, parsing is the bottleneck
+- If both are slow, focus on validation or database operations
+- Compare transaction overhead between `DatabaseInsertOnly` and `DatabaseInsertWithTransaction`
+
+**Common Bottlenecks:**
+- **Parsing > 50% of total time**: Optimize schema validation or consider async parsing
+- **High Gen2 collections**: Reduce memory allocations in hot paths
+- **Transaction overhead > 20%**: Consider batching strategies
+- **Validation > 30% of total time**: Cache validation results or optimize validators
+
+### Optimization Strategies
+
+Based on benchmark results:
+
+| Observation | Likely Cause | Optimization Strategy |
+|-------------|--------------|----------------------|
+| XML parsing > 2x JSON parsing | XML schema validation | Consider JSON-first approach or lazy validation |
+| High memory allocations | String concatenation, temporary objects | Use StringBuilder, object pooling |
+| Linear degradation with event count | O(n) operations in hot path | Consider parallel processing |
+| Transaction commit time dominates | Database I/O | Batch multiple requests, optimize indexes |
+| Validation time proportional to EPCs | Per-EPC validation overhead | Batch validate EPCs, use HashSet lookups |
+
+## Benchmark Results
+
+Baseline results (to be populated after first run):
+
+### Parsing Performance
+
+| Benchmark | Event Count | EPCs/Event | Mean | Allocated |
+|-----------|-------------|------------|------|-----------|
+| XmlParsing | 100 | 10 | TBD | TBD |
+| XmlParsing | 1000 | 50 | TBD | TBD |
+| JsonParsing | 100 | 10 | TBD | TBD |
+| JsonParsing | 1000 | 50 | TBD | TBD |
+
+### End-to-End Capture
+
+| Benchmark | Event Count | Mean | Allocated |
+|-----------|-------------|------|-----------|
+| CaptureXmlEndToEnd | 100 | TBD | TBD |
+| CaptureJsonEndToEnd | 100 | TBD | TBD |
+| CapturePreParsedRequest | 100 | TBD | TBD |
+
+### Component Performance
+
+| Benchmark | Event Count | Mean | Allocated |
+|-----------|-------------|------|-----------|
+| ValidateRequest | 1000 | TBD | TBD |
+| ComputeEventHashes | 1000 | TBD | TBD |
+| DatabaseInsertWithTransaction | 1000 | TBD | TBD |
+
+**Instructions for updating results:**
+1. Run benchmarks in Release mode on a clean system
+2. Record Mean and Allocated metrics for key configurations
+3. Update this table with baseline values
+4. Re-run after optimizations to track improvements
+
+## Test Data Configurations
+
+The `TestDataGenerator` provides preset configurations:
+
+| Size | Events | EPCs/Event | Total EPCs | Use Case |
+|------|--------|------------|------------|----------|
+| Small | 100 | 10 | 1,000 | Quick tests |
+| Medium | 500 | 20 | 10,000 | Standard documents |
+| Large | 1,000 | 50 | 50,000 | Large batches |
+| XLarge | 5,000 | 100 | 500,000 | Stress testing |
+
+## Adding New Benchmarks
+
+1. Create a new class in the project
+2. Add the `[Config(typeof(BenchmarkConfig))]` attribute
+3. Create benchmark methods with `[Benchmark]` attribute
+4. Use `[Params]` to test different input sizes
+5. Implement `[GlobalSetup]` and `[GlobalCleanup]` for initialization
+
+Example:
+
+```csharp
+[Config(typeof(BenchmarkConfig))]
+public class MyBenchmarks
+{
+    private EpcisContext _context;
+
+    [Params(100, 500, 1000)]
+    public int EventCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _context = BenchmarkDbContext.CreateInMemoryContext("MyBenchmark");
+    }
+
+    [Benchmark]
+    public async Task MyOperation()
+    {
+        // Benchmark code here
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        BenchmarkDbContext.Cleanup(_context);
+    }
+}
+```
+
+## Best Practices
+
+1. **Always use Release mode**: Debug builds include overhead that skews results
+2. **Close unnecessary applications**: Reduce system noise during benchmarking
+3. **Run multiple times**: Verify consistency across runs
+4. **Use realistic data**: Generate test data that matches production scenarios
+5. **Baseline comparisons**: Use `[Baseline]` attribute to compare implementations
+6. **Avoid I/O in hot path**: Database operations should be part of setup when measuring pure logic
+7. **Clean state**: Use `[IterationSetup]` if each iteration needs a fresh state
+
+## Troubleshooting
+
+### Benchmarks Running Slowly
+
+- Check if running in Debug mode (should be Release)
+- Verify no debugger is attached
+- Close resource-intensive applications
+
+### High Memory Usage
+
+- Use in-memory database for faster tests
+- Implement proper cleanup in `[GlobalCleanup]`
+- Check for memory leaks with memory profiler
+
+### Inconsistent Results
+
+- Reduce system load during benchmarking
+- Increase iteration count for more stable results
+- Check for background processes interfering
+
+## References
+
+- [BenchmarkDotNet Documentation](https://benchmarkdotnet.org/)
+- [BenchmarkDotNet Best Practices](https://benchmarkdotnet.org/articles/guides/good-practices.html)
+- [EPCIS 2.0 Standard](https://www.gs1.org/standards/epcis)


### PR DESCRIPTION
### Motivation
- Expand benchmark coverage so query benchmarks run against all prebuilt database sizes to better exercise real workloads.
- Harden limit tests to assert both exceeding and non-exceeding behavior for the capture limit.
- Remove unused test package/project references to avoid extra dependencies in `FasTnT.Host.Tests`.

### Description
- Removed the unused `PackageReference` and `ProjectReference` entries from `tests/FasTnT.Host.Tests/FasTnT.Host.Tests.csproj` to simplify test project configuration.
- Expanded `QueryBenchmarks` `Params` to `1000, 10000, 50000` by updating `tests/FasTnT.PerformanceTests/Benchmarks/QueryBenchmarks.cs` so benchmarks run against all prebuilt datasets.
- Strengthened `LimitTestBenchmarks` in `tests/FasTnT.PerformanceTests/Benchmarks/LimitTestBenchmarks.cs` by adding an explicit assertion that fails if a `CaptureLimitExceededException` is thrown for allowed counts (<= 500).

### Testing
- No automated unit or integration tests were executed for these changes.
- The changes were committed to a review branch (`pr-1-fixes`) for inspection and a PR was prepared against the original `pr-1` branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952620bb5508327abb89b6b9a3c840a)